### PR TITLE
Allow use of deep get keys for value and display.

### DIFF
--- a/addon/components/select-light.js
+++ b/addon/components/select-light.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { isNone } from '@ember/utils';
+import { get } from '@ember/object';
 import { deprecate } from '@ember/debug';
 
 const noop = () => {};
@@ -24,8 +25,8 @@ export default class extends Component {
 
   get hasDetailedOptions() {
     return ![ // Returns a boolean if all data is available for a { label: foo, value: bar } style list of options
-      this.args.options?.[0][this.valueKey],
-      this.args.options?.[0][this.displayKey],
+      this.args.options && get(this.args.options[0], this.valueKey),
+      this.args.options && get(this.args.options[0], this.displayKey),
     ].some(isNone);
   }
 }

--- a/tests/integration/components/select-light-test.js
+++ b/tests/integration/components/select-light-test.js
@@ -161,6 +161,29 @@ module('Integration | Component | select-light', function(hooks) {
 		assert.dom('select option').includesText(options[0].description);
 	});
 
+	test('should render options with customized value and display keys when passed ember get keys', async function(assert) {
+		let options = [
+			{ val: {id:'shortfin'}, description: 'Shortfin Shark' },
+			{ val: {id:'mako'}, description: 'Mako Shark' },
+		];
+		let value = options[1].val;
+		this.setProperties({
+			options,
+			value: value.id,
+		});
+
+		await render(hbs`
+      <SelectLight
+        @options={{this.options}}
+        @value={{this.value}}
+        @valueKey="val.id"
+        @displayKey="description" />
+    `);
+
+		assert.dom('select option').hasAttribute('value', options[0].val.id);
+		assert.dom('select option').includesText(options[0].description);
+	});
+
 	test('should render options correctly when value is an empty string', async function(assert) {
 		let options = [
 			{ value: '', label: 'None' },


### PR DESCRIPTION
When passing the `valueKey` and `displayKey` values, it would be helpful to use deep Ember `get` keys (for example, from `[{account:{id: 5}}]` using a get key `firstObject.account.id` would yield 5. Due to the syntax chosen for `hasDetailedOptions`, the deep keys are never displayed (even though the template allows for them). Using the Ember `get` method allows for this style of use.